### PR TITLE
Prevent mutation of last point

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -44,5 +44,11 @@ module.exports.orientRings = function orientRings(coordinates, depth, isHole) {
     }
   }
 
+  if (depth === 0 && typeof coordinates[0][0][0] === 'number') {
+    var clone = coordinates[0].slice(0, 1)[0];
+    coordinates[0].pop();
+    coordinates[0].push([clone[0], clone[1]]);
+  }
+
   return coordinates;
 };

--- a/test/offset.test.js
+++ b/test/offset.test.js
@@ -80,5 +80,17 @@ tap.test('polygon.offset', function(t) {
     t.end();
   });
 
+  t.test('Avoid mutation of last point of polygons', function(t) {
+    var out = new Offset([
+      [0,0], [0,100],
+      [100,100], [100,0], [0,0]
+    ]).offset(5);
+    out[0][0][0] = 'foo';
+    t.is(out[0][0][0], 'foo');
+    t.is(out[0][out[0].length - 1][0], -5);
+
+    t.end();
+  });
+
   t.end();
 });


### PR DESCRIPTION
Hey @w8r 

Been dabbling with this and one thing I noticed was that the output polygons were giving me grief because   the first and last coords were referencing eachother (eg modify one and you modified the other).

Not sure if this is the most optimal way to resolve the issue but it does the job.

Cheers